### PR TITLE
Added support for symlinked directories.

### DIFF
--- a/lib/s3_website/uploader.rb
+++ b/lib/s3_website/uploader.rb
@@ -152,7 +152,7 @@ module S3Website
     end
 
     def self.load_all_local_files(site_dir)
-      Dir.glob(site_dir + '**{,/*/**}/*', File::FNM_DOTMATCH).
+      Dir.glob(site_dir + '/**{,/*/**}/*', File::FNM_DOTMATCH).
         delete_if { |f| File.directory?(f) }.
         map { |f| f.gsub(site_dir + '/', '') }
     end


### PR DESCRIPTION
In relation to this issue: https://github.com/laurilehmijoki/s3_website/issues/3 

I've pushed a fix in filey-diff (https://github.com/laurilehmijoki/filey-diff/pull/5) and also added this small change to fix the issue. Symlinks should now be followed to one depth (to prevent recursive links). 

I might have missed out other directory traversals. I am also not familiar with ruby so you might want to review it.
