### PR TITLE
Specify config_dir when pushing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Let's say the contents you wish to upload to your S3 website bucket are in
 *my_website_output*. You can upload the contents of that directory with
 `s3_website push --site my_website_output`.
 
+If you want to store the `s3_website.yml` file in a directory other than
+the project's root you can specify the directory.
+`s3_website push --config_dir config`.
+
 ### Using environment variables
 
 You can use ERB in your `s3_website.yml` file which incorporates environment variables:

--- a/bin/s3_website
+++ b/bin/s3_website
@@ -36,6 +36,12 @@ class Cli < Thor
     :desc =>
       'When headless, s3_website will not require human interaction at any point'
   )
+  option(
+    :config_dir,
+    :type => :string,
+    :default => Dir.pwd,
+    :desc => "The directory where your config file is. When not defined, s3_website will look in the current working directory."
+  )
   desc 'push', 'Push local files with the S3 website'
   long_desc <<-LONGDESC
     `s3_website push` will upload new and changes files to S3. It will
@@ -43,7 +49,7 @@ class Cli < Thor
   LONGDESC
   def push
     site_path = S3Website::Paths.infer_site_path options[:site]
-    S3Website::Tasks.push(Dir.pwd, site_path, options[:headless])
+    S3Website::Tasks.push(options[:config_dir], site_path, options[:headless])
   end
 
   desc 'cfg SUBCOMMAND ...ARGS', 'Operate on the config file'


### PR DESCRIPTION
I'm working on a project that's a little bit unconventional. We have 3 config files and I want to group them together in a `config` directory. Specifying a config_dir is already supported by `S3Website::Tasks.push` so this patch lets you specify it from the command line.

```
$ s3_website push --config_dir config
```
