### PR TITLE
Add support for eu-west-1 as a location constraint

### DIFF
--- a/lib/s3_website/endpoint.rb
+++ b/lib/s3_website/endpoint.rb
@@ -15,11 +15,18 @@ module S3Website
 
     # http://docs.amazonwebservices.com/general/latest/gr/rande.html#s3_region
     def location_constraints
+      eu_west_1_region = {
+        :region           => 'EU (Ireland)',
+        :website_hostname => 's3-website-eu-west-1.amazonaws.com',
+        :endpoint         => 's3-eu-west-1.amazonaws.com'
+      }
+
       {
         'us-east-1'      => { :region => 'US Standard',                   :website_hostname => 's3-website-us-east-1.amazonaws.com',      :endpoint => 's3.amazonaws.com' },
         'us-west-2'      => { :region => 'US West (Oregon)',              :website_hostname => 's3-website-us-west-2.amazonaws.com',      :endpoint => 's3-us-west-2.amazonaws.com' },
         'us-west-1'      => { :region => 'US West (Northern California)', :website_hostname => 's3-website-us-west-1.amazonaws.com',      :endpoint => 's3-us-west-1.amazonaws.com' },
-        'EU'             => { :region => 'EU (Ireland)',                  :website_hostname => 's3-website-eu-west-1.amazonaws.com',      :endpoint => 's3-eu-west-1.amazonaws.com' },
+        'EU'             => eu_west_1_region,
+        'eu-west-1'      => eu_west_1_region,
         'ap-southeast-1' => { :region => 'Asia Pacific (Singapore)',      :website_hostname => 's3-website-ap-southeast-1.amazonaws.com', :endpoint => 's3-ap-southeast-1.amazonaws.com' },
         'ap-southeast-2' => { :region => 'Asia Pacific (Sydney)',         :website_hostname => 's3-website-ap-southeast-2.amazonaws.com', :endpoint => 's3-ap-southeast-2.amazonaws.com' },
         'ap-northeast-1' => { :region => 'Asia Pacific (Tokyo)',          :website_hostname => 's3-website-ap-northeast-1.amazonaws.com', :endpoint => 's3-ap-northeast-1.amazonaws.com' },

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -17,6 +17,11 @@ describe S3Website::Endpoint do
     endpoint.location_constraint.should eq('EU')
   end
 
+  it 'takes eu-west-1 as an alias for EU' do
+    endpoint = S3Website::Endpoint.new('eu-west-1')
+    endpoint.location_constraint.should eq('eu-west-1')
+  end
+
   it 'fails if the location constraint is invalid' do
     expect {
       S3Website::Endpoint.new('andromeda')


### PR DESCRIPTION
It's an alias for 'EU': http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

'EU' is the only constraint that's not the the name of a region, so I tried to use 'eu-west-1' the first time.
