### PR TITLE
AfterUploadTask > Sitemap Ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,13 @@ For more information on configuring redirects, see the documentation of the
 gem, which comes as a transitive dependency of the `s3_website` gem. (The
 command `s3_website cfg apply` internally calls the `configure-s3-website` gem.)
 
+###Submitting Sitemaps automatically
+
+If you want to submit your [generated Sitemap](https://github.com/kinnetica/jekyll-plugins) to Google + Bing automatically, you should add the following to your s3_website.yml file. 
+
+url: http://<your_website_address>/ #Your HTTP website address
+sitemap: sitemap.xml #Your sitemap filename. It is really recommended to keep it as sitemap.xml
+
 ### Using `s3_website` as a library
 
 By nature, `s3_website` is a command-line interface tool. You can, however, use

--- a/lib/s3_website.rb
+++ b/lib/s3_website.rb
@@ -12,6 +12,7 @@ module S3Website
 end
 
 %w{
+  after_upload_tasks
   errors
   upload
   uploader

--- a/lib/s3_website/after_upload_tasks.rb
+++ b/lib/s3_website/after_upload_tasks.rb
@@ -1,0 +1,25 @@
+module S3Website
+class AfterUploadTasks
+	def self.ping_sitemaps(config_file_dir)
+		require 'net/http'
+		require 'uri'
+		config = S3Website::ConfigLoader.load_configuration config_file_dir
+		puts "Pinging Sitemap to Google + Bing"
+		puts "Your Sitemap.xml is located at: "+URI.escape(config['url'] +config['sitemap'])
+		Net::HTTP.get(
+			'www.google.com',
+			'/webmasters/tools/ping?sitemap=' +
+			URI.escape(config['url'] +config['sitemap'])
+		)
+		Net::HTTP.get(
+			'www.bing.com',
+			'/ping?sitemap=' +
+			URI.escape(config['url'] +config['sitemap'])
+		)
+		puts "Pinged Sitemap servers!"
+    rescue S3WebsiteError => e
+      puts e.message
+      exit 1
+    end
+end
+end

--- a/lib/s3_website/tasks.rb
+++ b/lib/s3_website/tasks.rb
@@ -15,6 +15,9 @@ module S3Website
         :invalidated_items_count => invalidated_items_count,
         :changed_redirects_count => changed_redirects.size
       }
+	  if config.has_key?("sitemap")
+		S3Website::AfterUploadTasks.ping_sitemaps(config_file_dir)
+	  end	  
     rescue S3WebsiteError => e
       puts e.message
       exit 1


### PR DESCRIPTION
This add's a AfterUploadTask class, with a sitemap pinger activity. 
This is to ping both Google and Bing after an upload to S3 has been successful.

It is to be used in conjunction with the Sitemap generator https://github.com/kinnetica/jekyll-plugins .
Simply add url: <url>, sitemap: sitemap.xml to s3_website.cfg
I've made url seperate from sitemap config options for later use.

I'm not a Ruby coder so I appreciate any comments, unfortunately my test skills on Ruby are seriously lacking so there are no unit tests for the changes.
