### PR TITLE
set tempfile to binary mode to prevent corrupted gzip on windows

### DIFF
--- a/lib/s3_website/upload.rb
+++ b/lib/s3_website/upload.rb
@@ -49,6 +49,7 @@ module S3Website
 
     def gzipped_file
       tempfile = Tempfile.new(File.basename(path))
+      tempfile.binmode
 
       gz = Zlib::GzipWriter.new(tempfile, Zlib::BEST_COMPRESSION, Zlib::DEFAULT_STRATEGY)
 


### PR DESCRIPTION
It works fine on Linux but when attempting a push to s3 on Windows with Ruby 1.9.3, the gzipped files come out corrupted. Similar to this issue: http://stackoverflow.com/questions/3689963/ruby-zlibgzip-not-working-properly

Switching the tempfile to binary mode solves this issue and produces proper gzip output.

In conjunction with this pull request for filey-diff: https://github.com/laurilehmijoki/filey-diff/pull/8
