### PR TITLE
convert encoding of file path from utf8-mac to utf-8

### DIFF
--- a/lib/s3_website/diff_helper.rb
+++ b/lib/s3_website/diff_helper.rb
@@ -6,6 +6,10 @@ module S3Website
           progress_indicator.render_next_step
         }
         fs_data_source = Filey::DataSources::FileSystem.new(site_dir) { |filey|
+          if RUBY_PLATFORM =~ /darwin/
+            filey.instance_variable_set(:@name, filey.name.force_encoding('UTF8-MAC').encode('UTF-8'))
+            filey.instance_variable_set(:@path, filey.path.force_encoding('UTF8-MAC').encode('UTF-8'))
+          end
           progress_indicator.render_next_step
         }
         changed_local_files = Filey::Comparison.list_changed(

--- a/lib/s3_website/upload.rb
+++ b/lib/s3_website/upload.rb
@@ -15,8 +15,16 @@ module S3Website
       @config = config
     end
 
+    def s3_path
+      if RUBY_PLATFORM =~ /darwin/
+        path.force_encoding("UTF8-MAC").encode("UTF-8")
+      else
+        path
+      end
+    end
+
     def perform!
-      success = s3.buckets[config['s3_bucket']].objects[path].write(upload_file, upload_options)
+      success = s3.buckets[config['s3_bucket']].objects[s3_path].write(upload_file, upload_options)
       upload_file.close
       success
     end

--- a/lib/s3_website/uploader.rb
+++ b/lib/s3_website/uploader.rb
@@ -130,6 +130,7 @@ module S3Website
 
       remote_files = s3.buckets[s3_bucket_name].objects.map { |f| f.key }
       local_files = load_all_local_files(site_dir) + options.fetch(:redirects).keys
+      local_files = local_files.map{|x| x.force_encoding('UTF8-MAC').encode('UTF-8')} if RUBY_PLATFORM =~ /darwin/
       files_to_delete = build_list_of_files_to_delete(remote_files, local_files, options[:ignore_on_server])
 
       deleted_files = []


### PR DESCRIPTION
File path encoded with utf-mac in Mac OS, so convert to utf-8 when upload to S3.
