### PR TITLE
Added gzip_zopfli option

### DIFF
--- a/s3_website.gemspec
+++ b/s3_website.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mime-types', '~> 1'
   s.add_dependency 'thor', '= 0.18.1'
   s.add_dependency 'configure-s3-website', '= 1.5.2'
+  s.add_dependency 'zopfli', '~> 0.0.3'
 
   s.add_development_dependency 'rspec', '2.14.0'
   s.add_development_dependency 'rspec-expectations', '2.14.4'

--- a/spec/lib/upload_spec.rb
+++ b/spec/lib/upload_spec.rb
@@ -114,7 +114,7 @@ describe S3Website::Upload do
         }
       end
     end
-  end
+  end  
 
   describe 'gzip compression' do
     let(:config){
@@ -146,8 +146,28 @@ describe S3Website::Upload do
         subject.stub(:path).and_return('index.bork')
         subject.should be_gzip
       end
-    end
+    end       
 
+    describe '#gzipped_file' do
+      it 'should return a gzipped version of the file' do
+        gz = Zlib::GzipReader.new(subject.send(:gzipped_file))
+        gz.read.should == File.read('features/support/test_site_dirs/my.blog.com/_site/index.html')
+      end
+    end
+  end
+  
+  describe 'gzip zopfli' do
+    let(:config){
+      {
+        's3_reduced_redundancy' => false,
+        'gzip' => true,
+        'gzip_zopfli' => true
+      }
+    }
+
+    subject{ S3Website::Upload.new("index.html", mock(), config, 'features/support/test_site_dirs/my.blog.com/_site') }
+
+    # Zopfli should be compatible with the gzip format
     describe '#gzipped_file' do
       it 'should return a gzipped version of the file' do
         gz = Zlib::GzipReader.new(subject.send(:gzipped_file))


### PR DESCRIPTION
Google's Zopfli gzip-compatible compression algorithm takes longer to run but results in a 5% better compression on average.

I think having the option of using Zopfli with s3_website would be a nice feature to have. This pull request makes the necessary changes to require the Zopfli gem and if you include the config parameter "gzip_zopfli: true" then it will use the Zopfli algorithm.

This has previously been requested as an option here: https://github.com/laurilehmijoki/s3_website/issues/49
