### PR TITLE
Add smart redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ redirects:
   music-files/promo.mp4: http://www.youtube.com/watch?v=dQw4w9WgXcQ
 ```
 
+To setup up redirects for both trailing slash as well as a URL without the trailing slash, use '/' to end the path URL:
+
+```yaml
+redirects:
+  /about/: /about_me
+  /about/blog/: /about_blog
+```
+
 #### Routing Rules
 
 You can configure more complex redirect rules by adding the following


### PR DESCRIPTION
The way redirects are created currently is by creating a file in the bucket and setting a meta tag to it. The issue here is that this implementation does not support both trailing slash and non-trailing slash URLS. 

This commit fixes that issue. What are your thoughts on having this feature built-in?
