### PR TITLE
Don't fear minor version bumps (1.x)

### DIFF
--- a/s3_website.gemspec
+++ b/s3_website.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |s|
   s.default_executable = %q{s3_website}
 
   s.add_dependency 'aws-sdk', '~> 1'
-  s.add_dependency 'filey-diff', '~> 2.0.0'
+  s.add_dependency 'filey-diff', '~> 2.0'
   s.add_dependency 'simple-cloudfront-invalidator', '~> 1'
-  s.add_dependency 'erubis', '~> 2.7.0'
+  s.add_dependency 'erubis', '~> 2.7'
   s.add_dependency 'mime-types', '~> 1'
-  s.add_dependency 'thor', '= 0.18.1'
-  s.add_dependency 'configure-s3-website', '= 1.5.5'
+  s.add_dependency 'thor', '~> 0.18.1'
+  s.add_dependency 'configure-s3-website', '~> 1.5'
   s.add_dependency 'zopfli', '~> 0.0.3'
   s.add_dependency 'dotenv', '~> 0.11.1'
 


### PR DESCRIPTION
There should be no need to lock stable gems to a minor version.
