### PR TITLE
Adds config-dir as option to `cfg apply`

### DIFF
--- a/bin/s3_website
+++ b/bin/s3_website
@@ -33,6 +33,12 @@ class Cfg < Thor
     :type => :boolean,
     :desc => "When used with --headless, automatically create a CloudFront distribution for your S3 website."
   )
+  option(
+    'config-dir',
+    :type => :string,
+    :desc => "The directory where your config file is. When not defined, s3_website will look in the current working directory.",
+    :default => "."
+  )
   desc 'apply', 'Apply the configuration on the AWS services'
   long_desc <<-LONGDESC
     `s3_website cfg apply` will apply the configuration the S3 bucket.
@@ -45,7 +51,7 @@ class Cfg < Thor
   def apply
     puts 'Applying the configurations in s3_website.yml on the AWS services ...'
     require 'configure-s3-website'
-    config_source = ConfigureS3Website::FileConfigSource.new 's3_website.yml'
+    config_source = ConfigureS3Website::FileConfigSource.new "#{options['config-dir']}/s3_website.yml"
     ConfigureS3Website::Runner.run({
       :config_source => config_source,
       :headless => options[:headless],


### PR DESCRIPTION
`push` allows a user to set a config-directory, which is great for having a staging and production environment. However, `cfg apply` does not support this same thing. This PR fixes that. 

I am in a situation where I have different configs for staging and production, but shared credentials (through `.env`). This means I need to run the command from the root, but my config files need to live in different directories (`config/production`, `config/staging`). I am actually editing my configs frequently (redirects mostly), so this adds a lot of utility for that use case.

I would love to add tests to this, but I don't know the first thing about Scala. I have just made edits to my local version of this gem in order to test (and I've been using it daily). However I have not been able to successfully build my own version of this gem because of the following error. 

```
s3_website at /Users/vox/adonit/s3_website did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["resources/s3_website.jar.md5"] are not files
```

It's possible (and likely) that I'm just doing something wrong. Thanks for the gem!
