### PR TITLE
Invalidate the root /index.html when invalidating default root objs

### DIFF
--- a/src/test/scala/s3/website/S3WebsiteSpec.scala
+++ b/src/test/scala/s3/website/S3WebsiteSpec.scala
@@ -215,7 +215,7 @@ class S3WebsiteSpec extends Specification {
       setLocalFile("articles/index.html")
       setOutdatedS3Keys("articles/index.html")
       push
-      sentInvalidationRequest.getInvalidationBatch.getPaths.getItems.toSeq.sorted must equalTo(("/articles/" :: Nil).sorted)
+      sentInvalidationRequest.getInvalidationBatch.getPaths.getItems.toSeq.sorted must equalTo(("/articles/" :: "/index.html" :: Nil).sorted)
     }
   }
 


### PR DESCRIPTION
When using the cloudfront_invalidate_root config option, it will correctly invalidate all default root objects from /index.html to /, however this causes an issue on the root /index.html for the website, as some browsers redirect http://example.org/ to http://example.org which will request the /index.html and as this hasn't been invalidated will serve the cached index.html.

This change just adds /index.html to the paths to be invalidated if the config option is set to true

This helps somewhat with the issue #106
