### PR TITLE
Gzip .ico by default, closes #147

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ gzip: true
 ```
 
 Note that you can additionally specify the file extensions you want to Gzip
-(`.html`, `.css`, `.js`, and `.txt` will be compressed when `gzip: true`):
+(`.html`, `.css`, `.js`, `.ico`, and `.txt` will be compressed when `gzip: true`):
 
 ```yaml
 gzip:

--- a/src/main/scala/s3/website/model/push.scala
+++ b/src/main/scala/s3/website/model/push.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 
 object Encoding {
 
-  val defaultGzipExtensions = ".html" :: ".css" :: ".js" :: ".txt" :: Nil
+  val defaultGzipExtensions = ".html" :: ".css" :: ".js" :: ".txt" :: ".ico" :: Nil
 
   case class Gzip()
   case class Zopfli()


### PR DESCRIPTION
Add .ico to list of extensions that are gzipped by default.