### PR TITLE
Adding mention of --headless option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ When you run the command `s3_website cfg apply`, it will ask you whether you
 want to deliver your website via CloudFront. If you answer yes, the command will
 create a CloudFront distribution for you.
 
+If you do not want to receive this prompt, or if you are running the command in a non-interactive session, you can use `s3_website cfg apply --headless`.
+
 #### Using your existing CloudFront distribution
 
 If you already have a CloudFront distribution that serves data from your website


### PR DESCRIPTION
I was configuring s3_website as part of a Travis CI build recently. Other developers will be adding redirects to the repo, so I wanted to make sure those redirects were applied to our staging S3 bucket.

Travis would break when running `s3_website cfg apply`, since it's non-interactive, but I found a reference to the `--headless` option in the configure-s3-website repo.

I figured it would be helpful to mention it in this repo too. Thanks so much for working on this project - it's been the perfect fit for our current team.