### PR TITLE
Middleman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 * Create and configure an S3 website for you
 * Upload your static website to AWS S3
- * Jekyll and Nanoc are automatically supported
+* [Jekyll](http://jekyllrb.com/), [Nanoc](http://nanoc.ws/), and [Middleman](https://middlemanapp.com/) are automatically supported
 * Help you use AWS Cloudfront to distribute your website
 * Improve page speed with HTTP cache control and gzipping
 * Set HTTP redirects for your website
@@ -74,8 +74,7 @@ syntax information.
 * Let the user have all the S3 website configurations in a file
 * Minimise or remove the need to use the AWS Console
 * Allow the user to deliver the website via CloudFront
-* Automatically detect the most common static website tools, such as Jekyll or
-  Nanoc
+* Automatically detect the most common static website tools, such as [Jekyll](http://jekyllrb.com/), [Nanoc](http://nanoc.ws/), and [Middleman](https://middlemanapp.com/).
 * Be simple to use: require only the S3 credentials and the name of the S3
   bucket
 * Let the power users benefit from advanced S3 website features such as

--- a/s3_website.gemspec
+++ b/s3_website.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`
                       .split("\n")
                       .reject { |f| f.match('sbt-launch.jar') } # Reject the SBT jar, as it is a big file
-                      .push('resources/s3_website.jar.md5') # Include the checksum file in the gem
   s.test_files    = `git ls-files -- src/test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]

--- a/src/main/scala/s3/website/model/ssg.scala
+++ b/src/main/scala/s3/website/model/ssg.scala
@@ -9,7 +9,7 @@ trait Ssg {
 }
 
 object Ssg {
-  val automaticallySupportedSiteGenerators = Jekyll :: Nanoc :: Nil
+  val automaticallySupportedSiteGenerators = Jekyll :: Nanoc :: Middleman :: Nil
 
   val maxAutodetectDepth = automaticallySupportedSiteGenerators.map(_.outputDirectory).map(_.split(File.separatorChar).length).max
 
@@ -25,4 +25,8 @@ case object Jekyll extends Ssg {
 
 case object Nanoc extends Ssg {
   def outputDirectory = s"public${File.separatorChar}output"
+}
+
+case object Middleman extends Ssg {
+  def outputDirectory = "build"
 }

--- a/src/test/scala/s3/website/S3WebsiteSpec.scala
+++ b/src/test/scala/s3/website/S3WebsiteSpec.scala
@@ -1058,6 +1058,14 @@ class S3WebsiteSpec extends Specification {
     }
   }
 
+  "Middleman site" should {
+    "be detected automatically" in new MiddlemanSite with EmptySite with MockAWS with DefaultRunMode {
+      setLocalFile("index.html")
+      push()
+      sentPutObjectRequests.length must equalTo(1)
+    }
+  }
+
   "the setting treat_zero_length_objects_as_redirects" should {
     "skip application of redirect on a zero-length S3 object" in new BasicSetup {
       config =
@@ -1106,11 +1114,11 @@ class S3WebsiteSpec extends Specification {
       sentPutObjectRequest.getRedirectLocation must equalTo("/index.html")
     }
   }
-  
+
   trait BasicSetup extends SiteLocationFromCliArg with EmptySite with MockAWS with DefaultRunMode
 
   trait ForcePush extends SiteLocationFromCliArg with EmptySite with MockAWS with ForcePushMode
-  
+
   trait DryRun extends SiteLocationFromCliArg with EmptySite with MockAWS with DryRunMode
 
   trait DefaultRunMode {
@@ -1308,6 +1316,11 @@ class S3WebsiteSpec extends Specification {
 
   trait NanocSite extends Directories {
     val siteDirectory = new File(workingDirectory, "public/output")
+    val siteDirFromCLIArg = false
+  }
+
+  trait MiddlemanSite extends Directories {
+    val siteDirectory = new File(workingDirectory, "build")
     val siteDirFromCLIArg = false
   }
 


### PR DESCRIPTION
This PR adds support for [Middleman](https://middlemanapp.com/) sites.  The other commit in this PR removes a reference to a file that doesn't exist in version control.  With that line left in place in the gemspec, the gem won't build from source.  I'm happy to remove that commit, if I'm misunderstanding what's going on, but thought I'd add for the time-being.