### PR TITLE
do not match files like denver.html with a bad regex

### DIFF
--- a/lib/s3_website/upload.rb
+++ b/lib/s3_website/upload.rb
@@ -5,7 +5,7 @@ require 'zopfli'
 module S3Website
   class Upload
     attr_reader :config, :file, :path, :full_path, :s3
-    BLACKLISTED_FILES = ['s3_website.yml', '.env']
+    BLACKLISTED_FILES = %r{/?s3_website.yml$}, %r{/?\.env$}
 
     def initialize(path, s3, config, site_dir)
       raise "May not upload #{path}, because it's blacklisted" if Upload.is_blacklisted(path, config)


### PR DESCRIPTION
the current 1.x branch will *never* deploy a file with a name like 'denver.html' because


```ruby

Regexp.new('.env') =~ 'denver.html' #=> true

```

for sure the BLACKLIST should be a list of regexes, not strings