### PR TITLE
closes #185: adding version block

### DIFF
--- a/additional-docs/setting-up-aws-credentials.md
+++ b/additional-docs/setting-up-aws-credentials.md
@@ -26,6 +26,7 @@ Here is the IAM Policy Document of the above setup:
 
 ```json
 {
+  "Version": "2008-10-17",
   "Statement": [
     {
       "Action": [


### PR DESCRIPTION
As per http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html#policies-grammar-bnf, a version block seems needed to validate the policy document