### PR TITLE
Ensure tmp file has correct ext for Tika to analyse

### DIFF
--- a/src/main/scala/s3/website/model/push.scala
+++ b/src/main/scala/s3/website/model/push.scala
@@ -65,7 +65,7 @@ case class Upload(originalFile: File, uploadType: UploadType)(implicit site: Sit
   lazy val contentType: Try[String] = tika map { tika =>
     val file = // This file contains the data that the user should see after decoding the the transport protocol (HTTP) encoding (practically: after ungzipping)
       if (fileIsGzippedByExternalBuildTool) {
-        val unzippedFile = createTempFile(originalFile.getName, "unzipped")
+        val unzippedFile = createTempFile("unzipped", originalFile.getName)
         unzippedFile.deleteOnExit()
         using(new GZIPInputStream(fis(originalFile))) { stream =>
           IOUtils.copy(stream, new FileOutputStream(unzippedFile))


### PR DESCRIPTION
By putting the actual file name (including its extensions) as the suffix of the tmp file, Tika will correctly identify it based on both its contents and its extension. Otherwise, Tika detects its mime type based on its contents alone (which is not sufficient for text files).

#229 @laurilehmijoki Can you confirm this works as expected? I haven't compiled and tested it yet, but I assume it will work. Before this patch I tested on a simple file with contents `{}` and name `test.json` and it was detected as `text/plain`. After this patch it should be detected as `application/json`.

Thanks for your quick work on this gzip issue!