### PR TITLE
aws credentials: use default provider chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,30 +52,13 @@ If you want to store the `s3_website.yml` file in a directory other than
 the project's root you can specify the directory like so:
 `s3_website push --config-dir config`.
 
-### Using environment variables
+### Authenticating
 
-You can use ERB in your `s3_website.yml` file which incorporates environment variables:
+s3_website now uses the AWS Java SDK's
+[default credential provider chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#id6).
 
-```yaml
-s3_id: <%= ENV['S3_ID'] %>
-s3_secret: <%= ENV['S3_SECRET'] %>
-s3_bucket: blog.example.com
-```
-
-(If you are using `s3_website` on an [EC2 instance with IAM
-roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UsingIAM.html#UsingIAMrolesWithAmazonEC2Instances),
-you can omit the `s3_id` and `s3_secret` keys in the config file.)
-
-S3_website implements supports for reading environment variables from a file using
-the [dotenv](https://github.com/bkeepers/dotenv) gem. You can create a `.env` file
-in the project's root directory to take advantage of this feature. Please have
-a look at [dotenv's usage guide](https://github.com/bkeepers/dotenv#usage) for
-syntax information.
-
-Your `.env` file should containing the following variables:
-
-    AWS_ACCESS_KEY_ID=FOO
-    AWS_SECRET_ACCESS_KEY=BAR
+You can specify your credentials in many ways,
+but they now must be done outside of the s3_website config file.
 
 ## Project goals
 

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -5,27 +5,14 @@ This document shows examples of complete `s3_website.yml` configurations.
 ## Minimal
 
 ````yaml
-s3_id: abcd
-s3_secret: 2s+x92
 s3_bucket: your.domain.net
 ````
-
-## Minimal with EC2 IAM roles
-
-````yaml
-s3_bucket: your.domain.net
-````
-
-If you run `s3_website` on an EC2 instance with IAM roles, it is possible to omit
-the `s3_id` and `s3_secret`.
 
 ## Optimised for speed
 
 Use CloudFront, gzip, cache headers and greater concurrency:
 
 ````yaml
-s3_id: <%= ENV['your_domain_net_aws_key'] %>
-s3_secret: <%= ENV['your_domain_net_aws_secret'] %>
 s3_bucket: your.domain.net
 cloudfront_distribution_id: <%= ENV['your_domain_net_cloudfront_distribution_id'] %>
 cloudfront_distribution_config:
@@ -49,8 +36,6 @@ version-controlled.
 Sometimes you want to use multiple CNAMEs aliases in your CloudFront distribution:
 
 ````yaml
-s3_id: <%= ENV['your_domain_net_aws_key'] %>
-s3_secret: <%= ENV['your_domain_net_aws_secret'] %>
 s3_bucket: your.domain.net
 cloudfront_distribution_id: <%= ENV['your_domain_net_cloudfront_distribution_id'] %>
 cloudfront_distribution_config:
@@ -71,8 +56,6 @@ Always remember to set the 'quantity' property to match the number of items you 
 ## Using redirects
 
 ````yaml
-s3_id: hello
-s3_secret: galaxy
 redirects:
   index.php: /
   about.php: about.html

--- a/resources/configuration_file_template.yml
+++ b/resources/configuration_file_template.yml
@@ -1,5 +1,4 @@
-s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
-s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
+---
 s3_bucket: your.blog.bucket.com
 
 # Below are examples of all the available configurations.
@@ -59,3 +58,4 @@ cloudfront_wildcard_invalidation: true
 #       host_name: blog.example.com
 #       replace_key_prefix_with: some_new_path/
 #       http_redirect_code: 301
+...

--- a/src/main/scala/s3/website/CloudFront.scala
+++ b/src/main/scala/s3/website/CloudFront.scala
@@ -7,10 +7,8 @@ import com.amazonaws.services.cloudfront.model.{TooManyInvalidationsInProgressEx
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 import s3.website.S3.{SuccessfulDelete, PushSuccessReport, SuccessfulUpload}
-import com.amazonaws.auth.BasicAWSCredentials
 import java.net.{URLEncoder, URI}
 import scala.concurrent.{ExecutionContextExecutor, Future}
-import s3.website.model.Config.awsCredentials
 
 object CloudFront {
   def invalidate(invalidationBatch: InvalidationBatch, distributionId: String, attempt: Attempt = 1)
@@ -65,7 +63,7 @@ object CloudFront {
     def reportMessage = errorMessage(s"Failed to invalidate the CloudFront distribution", error)
   }
 
-  def awsCloudFrontClient(config: Config) = new AmazonCloudFrontClient(awsCredentials(config))
+  def awsCloudFrontClient(config: Config) = new AmazonCloudFrontClient()
 
   def toInvalidationBatches(pushSuccessReports: Seq[PushSuccessReport])(implicit config: Config): Seq[InvalidationBatch] = {
     def callerReference = s"s3_website gem ${System.currentTimeMillis()}"

--- a/src/main/scala/s3/website/S3.scala
+++ b/src/main/scala/s3/website/S3.scala
@@ -12,7 +12,6 @@ import scala.concurrent.duration.TimeUnit
 import java.util.concurrent.TimeUnit.SECONDS
 import s3.website.S3.SuccessfulUpload.humanizeUploadSpeed
 import java.io.FileInputStream
-import s3.website.model.Config.awsCredentials
 import scala.util.Try
 
 object S3 {
@@ -113,7 +112,7 @@ object S3 {
     System.currentTimeMillis - start
   }
 
-  def awsS3Client(config: Config) = new AmazonS3Client(awsCredentials(config))
+  def awsS3Client(config: Config) = new AmazonS3Client()
 
   def resolveS3Files(nextMarker: Option[String] = None, alreadyResolved: Seq[S3File] = Nil,  attempt: Attempt = 1)
                               (implicit site: Site, s3Settings: S3Setting, ec: ExecutionContextExecutor, logger: Logger, pushOptions: PushOptions):

--- a/src/main/scala/s3/website/model/Config.scala
+++ b/src/main/scala/s3/website/model/Config.scala
@@ -8,11 +8,8 @@ import scala.util.{Failure, Try}
 import scala.collection.JavaConversions._
 import s3.website.Ruby.rubyRuntime
 import s3.website._
-import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
 
 case class Config(
-  s3_id:                                  Option[String], // If undefined, use IAM Roles (http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-roles.html)
-  s3_secret:                              Option[String], // If undefined, use IAM Roles (http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-roles.html)
   s3_bucket:                              String,
   s3_endpoint:                            S3Endpoint,
   site:                                   Option[String],
@@ -34,19 +31,6 @@ case class Config(
 )
 
 object Config {
-
-  def awsCredentials(config: Config): AWSCredentialsProvider = {
-    val credentialsFromConfigFile = for {
-      s3_id <- config.s3_id
-      s3_secret <- config.s3_secret
-    } yield new BasicAWSCredentials(s3_id, s3_secret)
-    credentialsFromConfigFile.fold(new DefaultAWSCredentialsProviderChain: AWSCredentialsProvider)(credentials =>
-      new AWSCredentialsProvider {
-        def getCredentials = credentials
-        def refresh() = {}
-      }
-    )
-  }
 
   def loadOptionalBooleanOrStringSeq(key: String)(implicit unsafeYaml: UnsafeYaml): Either[ErrorReport, Option[Either[Boolean, Seq[String]]]] = {
     val yamlValue = for {

--- a/src/main/scala/s3/website/model/Site.scala
+++ b/src/main/scala/s3/website/model/Site.scala
@@ -33,8 +33,6 @@ object Site {
       case Success(yamlObject) =>
         implicit val unsafeYaml = UnsafeYaml(yamlObject)
         for {
-          s3_id <- loadOptionalString("s3_id").right
-          s3_secret <- loadOptionalString("s3_secret").right
           s3_bucket <- loadRequiredString("s3_bucket").right
           s3_endpoint <- loadEndpoint.right
           site <- loadOptionalString("site").right
@@ -63,8 +61,6 @@ object Site {
             s"Ignoring the extensionless_mime_type setting in $yamlConfig. Counting on Apache Tika to infer correct mime types.")
           )
           Config(
-            s3_id,
-            s3_secret,
             s3_bucket,
             s3_endpoint getOrElse S3Endpoint.defaultEndpoint,
             site,

--- a/src/test/scala/s3/website/S3WebsiteSpec.scala
+++ b/src/test/scala/s3/website/S3WebsiteSpec.scala
@@ -1434,8 +1434,6 @@ class S3WebsiteSpec extends Specification {
     var config = ""
     val baseConfig =
     """
-      |s3_id: foo
-      |s3_secret: bar
       |s3_bucket: bucket
     """.stripMargin
 


### PR DESCRIPTION
This commit simplifies the initialization of AWS connections,
by falling back to the default provider chain provided by the
AWS Java SDK.

Reasons for this breaking change:
- The existing code was not compatible with session tokens,
  and thus could not be used by users with assumed roles.
- The existing code was a big convoluted, and the default
  system is pretty elegant.
- Stashing these secrets in the s3_website.yml configuration
  represents a security risk, so should be discouraged.

I realize this is a bit presumptuous, but I didn't want to put in more effort than necessary to solve this problem. Let me know what you think

Fixes #217 
