### PR TITLE
[doc] Fix types for multiple CNAME settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ cloudfront_distribution_config:
   aliases:
     quantity: 1
     items:
-      CNAME: your.website.com
+      - your.website.com
 ```
 
 Once you've saved the configuration into `s3_website.yml`, you can apply them by

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -34,7 +34,7 @@ cloudfront_distribution_config:
   aliases:
     quantity: 1
     items:
-      CNAME: your.domain.net
+      - your.domain.net
 max_age: 120
 gzip: true
 ````
@@ -59,9 +59,9 @@ cloudfront_distribution_config:
   aliases:
     quantity: 3
     items:
-      CNAME0: your1.domain.net
-      CNAME1: your2.domain.net
-      CNAME2: your3.domain.net
+      - your1.domain.net
+      - your2.domain.net
+      - your3.domain.net
 max_age: 120
 gzip: true
 ````


### PR DESCRIPTION
Not sure when this broken, but empirically an array is required rather
than a hash.