### PR TITLE
Documentation on http2 support

### DIFF
--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -35,7 +35,6 @@ cloudfront_distribution_config:
     quantity: 1
     items:
       - your.domain.net
-  http_version: http2
 max_age: 120
 gzip: true
 ````
@@ -44,6 +43,30 @@ Above, we store the AWS credentials and the id of the CloudFront distribution as
 environment variables. It's convenient, since you can keep the `s3_website.yml`
 in a public Git repo, and thus have your deployment configurations
 version-controlled.
+
+## Setup for HTTP2 and Custom SNI SSL Certificate
+
+While HTTP/2 does not mandate the use of encryption, it turns out that all of the 
+common web browsers require the use of HTTPS connections in conjunction with HTTP/2.
+Therefore, you may need to make some changes to your site or application in order 
+to take full advantage of HTTP/2. While you can test the site by using the Default
+CloudFront Certificate you will likely want to use a custom SSL Certificate. 
+This isn't yet automated by s3_website, (but is a few manual steps)[https://medium.
+com/@richardkall/setup-lets-encrypt-ssl-certificate-on-amazon-cloudfront-b217669987b2#.7jyust8os], 
+which is now free thanks to Let's Encrypt. 
+
+````yaml
+s3_id: <%= ENV['your_domain_net_aws_key'] %>
+s3_secret: <%= ENV['your_domain_net_aws_secret'] %>
+s3_bucket: your.domain.net
+cloudfront_distribution_id: <%= ENV['your_domain_net_cloudfront_distribution_id'] %>
+cloudfront_distribution_config:
+  default_cache_behavior:
+    min_TTL: <%= 60 * 60 * 24 %>
+  http_version: http2
+max_age: 120
+gzip: true
+````
 
 ## Multiple CNAMEs
 

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -21,7 +21,7 @@ the `s3_id` and `s3_secret`.
 
 ## Optimised for speed
 
-Use CloudFront, gzip, HTTP2, cache headers and greater concurrency:
+Use CloudFront, gzip, cache headers and greater concurrency:
 
 ````yaml
 s3_id: <%= ENV['your_domain_net_aws_key'] %>
@@ -46,8 +46,9 @@ version-controlled.
 
 ## Setup for HTTP2 and Custom SNI SSL Certificate
 
-While HTTP/2 does not mandate the use of encryption, it turns out that all of the 
-common web browsers require the use of HTTPS connections in conjunction with HTTP/2.
+To fully utilize HTTP2, you'll need to setup SSL for your distribution. While HTTP/2 does
+not mandate the use of encryption, it turns out that all of the common web browsers 
+require the use of HTTPS connections in conjunction with HTTP/2.
 Therefore, you may need to make some changes to your site or application in order 
 to take full advantage of HTTP/2. While you can test the site by using the Default
 CloudFront Certificate you will likely want to use a custom SSL Certificate. 

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -21,7 +21,7 @@ the `s3_id` and `s3_secret`.
 
 ## Optimised for speed
 
-Use CloudFront, gzip, cache headers and greater concurrency:
+Use CloudFront, gzip, HTTP2, cache headers and greater concurrency:
 
 ````yaml
 s3_id: <%= ENV['your_domain_net_aws_key'] %>
@@ -35,6 +35,7 @@ cloudfront_distribution_config:
     quantity: 1
     items:
       - your.domain.net
+  http_version: http2
 max_age: 120
 gzip: true
 ````

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -47,8 +47,8 @@ version-controlled.
 ## Setup for HTTP2 and Custom SNI SSL Certificate
 
 To fully utilize HTTP2 you'll need to setup SSL for your distribution. While HTTP/2 does
-not mandate the use of encryption, it turns out that all of the common web browsers 
-require the use of HTTPS connections in conjunction with HTTP/2.
+not mandate the use of encryption, it turns out that [all of the common web browsers 
+require the use of HTTPS connections in conjunction with HTTP/2](http://caniuse.com/#feat=http2).
 Therefore, you may need to make some changes to your site or application in order 
 to take full advantage of HTTP/2. While you can test the site by using the Default
 CloudFront Certificate you will likely want to use a custom SSL Certificate. 

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -46,7 +46,7 @@ version-controlled.
 
 ## Setup for HTTP2 and Custom SNI SSL Certificate
 
-To fully utilize HTTP2, you'll need to setup SSL for your distribution. While HTTP/2 does
+To fully utilize HTTP2 you'll need to setup SSL for your distribution. While HTTP/2 does
 not mandate the use of encryption, it turns out that all of the common web browsers 
 require the use of HTTPS connections in conjunction with HTTP/2.
 Therefore, you may need to make some changes to your site or application in order 

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -51,8 +51,8 @@ common web browsers require the use of HTTPS connections in conjunction with HTT
 Therefore, you may need to make some changes to your site or application in order 
 to take full advantage of HTTP/2. While you can test the site by using the Default
 CloudFront Certificate you will likely want to use a custom SSL Certificate. 
-This isn't yet automated by s3_website, (but is a few manual steps)[https://medium.
-com/@richardkall/setup-lets-encrypt-ssl-certificate-on-amazon-cloudfront-b217669987b2#.7jyust8os], 
+This isn't yet automated by s3_website, [but is a few manual steps](https://medium.
+com/@richardkall/setup-lets-encrypt-ssl-certificate-on-amazon-cloudfront-b217669987b2#.7jyust8os), 
 which is now free thanks to Let's Encrypt. 
 
 ````yaml

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -51,8 +51,7 @@ common web browsers require the use of HTTPS connections in conjunction with HTT
 Therefore, you may need to make some changes to your site or application in order 
 to take full advantage of HTTP/2. While you can test the site by using the Default
 CloudFront Certificate you will likely want to use a custom SSL Certificate. 
-This isn't yet automated by s3_website, [but is a few manual steps](https://medium.
-com/@richardkall/setup-lets-encrypt-ssl-certificate-on-amazon-cloudfront-b217669987b2#.7jyust8os), 
+This isn't yet automated by s3_website, [but is a few manual steps](https://medium.com/@richardkall/setup-lets-encrypt-ssl-certificate-on-amazon-cloudfront-b217669987b2#.7jyust8os), 
 which is now free thanks to Let's Encrypt. 
 
 ````yaml


### PR DESCRIPTION
I initially tested this with a fresh setup. The setting does work, but since AWS Cloudfront [only utilizes HTTP2 using HTTPS](https://aws.amazon.com/blogs/aws/new-http2-support-for-cloudfront/)  

I created a new section that includes how to setup a SNI SSL cert with Let's Encrypt, or I can add documentation for [AWS Certificate Manager](https://github.com/laurilehmijoki/s3_website/issues/202#issuecomment-255569108) if that's the preferred method. 