### PR TITLE
Update documentation to support changes for configure-s3-website@V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ For example, like this you can define a your own TTL and CNAME:
 ```yaml
 cloudfront_distribution_config:
   default_cache_behavior:
-    min_TTL: <%= 60 * 60 * 24 %>
+    min_ttl: <%= 60 * 60 * 24 %>
   aliases:
     quantity: 1
     items:

--- a/additional-docs/example-configurations.md
+++ b/additional-docs/example-configurations.md
@@ -30,7 +30,7 @@ s3_bucket: your.domain.net
 cloudfront_distribution_id: <%= ENV['your_domain_net_cloudfront_distribution_id'] %>
 cloudfront_distribution_config:
   default_cache_behavior:
-    min_TTL: <%= 60 * 60 * 24 %>
+    min_ttl: <%= 60 * 60 * 24 %>
   aliases:
     quantity: 1
     items:
@@ -62,7 +62,7 @@ s3_bucket: your.domain.net
 cloudfront_distribution_id: <%= ENV['your_domain_net_cloudfront_distribution_id'] %>
 cloudfront_distribution_config:
   default_cache_behavior:
-    min_TTL: <%= 60 * 60 * 24 %>
+    min_ttl: <%= 60 * 60 * 24 %>
   http_version: http2
 max_age: 120
 gzip: true
@@ -79,7 +79,7 @@ s3_bucket: your.domain.net
 cloudfront_distribution_id: <%= ENV['your_domain_net_cloudfront_distribution_id'] %>
 cloudfront_distribution_config:
   default_cache_behavior:
-    min_TTL: <%= 60 * 60 * 24 %>
+    min_ttl: <%= 60 * 60 * 24 %>
   aliases:
     quantity: 3
     items:

--- a/resources/configuration_file_template.yml
+++ b/resources/configuration_file_template.yml
@@ -35,11 +35,11 @@ s3_bucket: your.blog.bucket.com
 
 # cloudfront_distribution_config:
 #   default_cache_behavior:
-#     min_TTL: <%= 60 * 60 * 24 %>
+#     min_ttl: <%= 60 * 60 * 24 %>
 #   aliases:
 #     quantity: 1
 #     items:
-#       CNAME: your.website.com
+#       - your.website.com
 
 # cloudfront_invalidate_root: true
 


### PR DESCRIPTION
Context: Issue laurilehmijoki/configure-s3-website#17
Duplicate from PR laurilehmijoki/configure-s3-website#18 so the error string is searchable

As of Version 2.0.0, s3_website configurations in `s3_website.yml` should change from

```yaml
default_cache_behavior:
  min_TTL: 600
aliases:
  quantity: 1
  items:
    CNAME: my.site.net
```

to

```yaml
default_cache_behavior:
  min_ttl: 600
aliases:
  quantity: 1
  items:
   - my.site.net
```

Users who have not applied the change will get the following errors for the CNAME or min_TTL options, respectively:

```
expected params[:distribution_config][:aliases][:items][0] to be a String, got value [:CNAME, "example.com"] (class: Array) instead. (ArgumentError)

unexpected value at params[:distribution_config][:default_cache_behavior][:min_TTL] (ArgumentError)
```

[configure-s3-website V2.0.0 Changelog](https://github.com/laurilehmijoki/configure-s3-website/blob/master/changelog.md#200)